### PR TITLE
Added required csproj settings to make the Custom Vision Trainer a CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,29 @@ A small application that allows to automatically upload and  tag images for Cust
 | Specify the width of the images | **w** | width |
 | Specify the height of the images | **h** | height |
 | Set to just delete images and tags and exits | **d** | delete |
+
+### Installing the .NET CLI Tool
+In order to install the .NET CLI Tool version of this application, you need to simly type inside the command prompt the following command
+```console
+dotnet tool install -g CustomVisionTrainer
+```
+Or if you want to specify the version you can do that by doing
+```console
+dotnet tool install -g CustomVisionTrainer --version 1.0.0
+```
+If installation is successful, a message is displayed showing the command used to call the tool and the version installed, similar to the following example:
+
+```
+You can invoke the tool using the following command: cvtrainer
+Tool 'CustomVisionTrainer' (version '1.0.0') was successfully installed.
+```
+### Updating the .NET CLI Tool
+After a new release of this application , you can update the CLI Tool like this
+```console
+dotnet tool update -g CustomVisionTrainer
+```
+### Uninstalling the .NET CLI Tool
+In case you don't want this tool installed on your system any longer, you can remove it by doing
+```console
+dotnet tool uninstall -g CustomVisionTrainer
+```

--- a/Src/CustomVisionTrainer/CustomVisionTrainer.csproj
+++ b/Src/CustomVisionTrainer/CustomVisionTrainer.csproj
@@ -4,11 +4,19 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <Authors>Marco Minerva</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Copyright>Marco Minerva 2019</Copyright>
     <RepositoryUrl>https://github.com/marcominerva/customvision-trainer</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <LangVersion>7.3</LangVersion>
+    
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>cvtrainer</ToolCommandName>
+    <PackageOutputPath>./tool_release</PackageOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>NU1701;NU1702</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineArgumentsParser">


### PR DESCRIPTION
With very few tweaks to the .csproj file we can turn this console app into a .NET CLI Tool
Once installed [see](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) we can call it from the command prompt like
`cvtrainer <usual_params>` where *<usual_params>* is any parameter/logic currently supported by the tool